### PR TITLE
Use code profile for code-detected sources in chunking pipeline (#190)

### DIFF
--- a/engine/crates/covalence-core/src/ingestion/source_profile.rs
+++ b/engine/crates/covalence-core/src/ingestion/source_profile.rs
@@ -205,6 +205,17 @@ impl ProfileRegistry {
     }
 
     /// Find the best-matching profile for a source.
+    ///
+    /// Matching priority:
+    /// 1. URI prefix match (most specific — picks up profiles like
+    ///    `arxiv_paper` that are URI-keyed).
+    /// 2. Source type match, restricted to profiles without URI
+    ///    prefixes. This prevents URI-keyed profiles from being
+    ///    selected as a generic source-type fallback (e.g.,
+    ///    `arxiv_paper` shares `source_type=Document` with the
+    ///    generic `document` profile and would otherwise win the
+    ///    fallback for all non-arxiv documents because of vec order).
+    /// 3. Fallback to the document profile (the last entry).
     pub fn match_profile(&self, source_type: &SourceType, uri: Option<&str>) -> &SourceProfile {
         // Priority 1: URI prefix match.
         if let Some(uri) = uri {
@@ -219,8 +230,12 @@ impl ProfileRegistry {
             }
         }
 
-        // Priority 2: Source type match.
+        // Priority 2: Source type match. Skip URI-keyed profiles —
+        // they should only be selected via Priority 1.
         for profile in &self.profiles {
+            if !profile.uri_prefixes.is_empty() {
+                continue;
+            }
             if &profile.source_type == source_type {
                 return profile;
             }
@@ -265,6 +280,30 @@ mod tests {
     fn registry_falls_back_to_document() {
         let reg = ProfileRegistry::new();
         let profile = reg.match_profile(&SourceType::Observation, None);
+        assert_eq!(profile.name, "document");
+    }
+
+    #[test]
+    fn registry_document_type_does_not_select_arxiv_for_non_arxiv_uri() {
+        // Regression for #190: ARXIV_PAPER and DOCUMENT both share
+        // source_type=Document. Before the fix, the source_type loop
+        // returned the first match in vec order (arxiv) for any
+        // Document URL — including local code files reprocessed
+        // through the synchronous pipeline.
+        let reg = ProfileRegistry::new();
+        let profile = reg.match_profile(
+            &SourceType::Document,
+            Some("file:///path/to/chat_backend.rs"),
+        );
+        assert_eq!(profile.name, "document");
+    }
+
+    #[test]
+    fn registry_document_type_with_no_uri_picks_document() {
+        // Same regression: even without a URI, Document type must
+        // resolve to the generic document profile, not arxiv_paper.
+        let reg = ProfileRegistry::new();
+        let profile = reg.match_profile(&SourceType::Document, None);
         assert_eq!(profile.name, "document");
     }
 

--- a/engine/crates/covalence-core/src/services/pipeline/mod.rs
+++ b/engine/crates/covalence-core/src/services/pipeline/mod.rs
@@ -54,8 +54,21 @@ impl SourceService {
     /// dedup, supersession, or cleanup).
     pub(crate) async fn run_pipeline(&self, input: &PipelineInput<'_>) -> Result<PipelineOutput> {
         // Resolve source profile for per-type chunk parameters.
-        let source_type_enum = crate::models::source::SourceType::from_str_opt(input.source_type)
-            .unwrap_or(crate::models::source::SourceType::Document);
+        //
+        // `input.is_code` is set by `prepare_content` via URI/MIME
+        // detection (`code_chunker::detect_code_language`) and is
+        // authoritative for code dispatch. The PG row's `source_type`
+        // can lag (e.g. a `.rs` file added with `--type document`),
+        // so when `is_code` is true we must force the CODE profile —
+        // otherwise the file gets paragraph-chunked as a document
+        // and tree-sitter never produces per-entity chunks for the
+        // AST extractor (#190).
+        let source_type_enum = if input.is_code {
+            crate::models::source::SourceType::Code
+        } else {
+            crate::models::source::SourceType::from_str_opt(input.source_type)
+                .unwrap_or(crate::models::source::SourceType::Document)
+        };
         let registry = crate::ingestion::source_profile::ProfileRegistry::new();
         let profile = registry.match_profile(&source_type_enum, input.source_uri.as_deref());
         tracing::debug!(
@@ -399,9 +412,16 @@ impl SourceService {
 
             let extractable: Vec<_> = chunk_outputs.iter().collect();
 
+            // Use the profile's `min_extract_tokens` rather than the
+            // engine-wide default. The CODE profile sets this to 10
+            // because tree-sitter-derived sections like `struct Foo`
+            // are intentionally short (~20 tokens) — the global
+            // default of 30 would filter them out before extraction
+            // (#190 follow-up).
+            let min_extract_tokens = profile.min_extract_tokens;
             let batches = group_extraction_batches(
                 &extractable,
-                self.min_extract_tokens,
+                min_extract_tokens,
                 self.extract_batch_tokens,
                 resolved_texts.as_ref(),
             );
@@ -409,7 +429,7 @@ impl SourceService {
             tracing::debug!(
                 extractable = extractable.len(),
                 batches = batches.len(),
-                min_tokens = self.min_extract_tokens,
+                min_tokens = min_extract_tokens,
                 batch_budget = self.extract_batch_tokens,
                 "extraction batching"
             );


### PR DESCRIPTION
## Summary
- `ProfileRegistry::match_profile` now skips URI-keyed profiles when falling back to source-type matching, so `arxiv_paper` no longer wins for non-arxiv `Document` URLs (regression introduced by vec-order iteration).
- `run_pipeline` forces `SourceType::Code` when `input.is_code` is true so a `.rs` file added with `--type document` still gets the CODE profile — making runtime content detection authoritative over the PG row's `source_type`.
- `run_pipeline` now uses `profile.min_extract_tokens` instead of the engine-wide default, so tree-sitter's short `struct Foo` sections (≈20 tokens) aren't filtered out by the global threshold of 30.

These three sub-fixes together unblock end-to-end verification of #186 and #189 — the entire dispatch chain now correctly routes code files through the AST extractor.

Closes #190.

## Verification
After deploying and re-processing `chat_backend.rs`, all six target type names from #186 resolve as code-domain nodes:

| Name | entity_class | node_type |
|------|--------------|-----------|
| ChainChatBackend | code | struct |
| CliChatBackend | code | struct |
| FallbackChatBackend | code | struct |
| HttpChatBackend | code | struct |
| ChatBackend | code | trait |
| ChatResponse | code | struct |

Worker logs confirm:
```
DEBUG resolved source profile for chunking profile="code" chunk_size=2000 chunk_overlap=100
DEBUG extraction batching extractable=123 batches=3 min_tokens=10
DEBUG ast short-circuit: bypassing fuzzy/vector/tier5 entity=ChainChatBackend entity_type=struct
DEBUG ast short-circuit: bypassing fuzzy/vector/tier5 entity=CliChatBackend entity_type=struct
DEBUG ast short-circuit: bypassing fuzzy/vector/tier5 entity=FallbackChatBackend entity_type=struct
```

## Follow-up
The legacy `HttpChatBackend` LLM-noise node had to be cleaned up manually because the resolver matches by exact name and the existing `update_node_ast_hash` SP doesn't update `node_type`/`entity_class`. Filed as #191 — \"Resolver should promote LLM-typed nodes to AST when AST evidence becomes available.\"

## Test plan
- [x] `cargo test -p covalence-core --lib` — 1506 passing
- [x] `cargo clippy --workspace --lib -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Two new regression tests for the registry fix
- [x] End-to-end re-process of chat_backend.rs in prod, all 6 target names verified via `/api/v1/nodes/resolve`
- [x] cove llm code review — GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)