### PR TITLE
Fix dogfood bugs from session 43: search latency, chunker, CLI, dashboard

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -29,8 +29,21 @@ func Execute() {
 	}
 }
 
+// defaultAPIURL returns the API URL the CLI should target.
+//
+// Order of precedence: COVALENCE_API_URL env var, then a sensible
+// localhost default. Without the env-var fallback, running cove
+// against a non-default port (e.g. dev on 8441) requires passing
+// --api-url on every invocation.
+func defaultAPIURL() string {
+	if v := os.Getenv("COVALENCE_API_URL"); v != "" {
+		return v
+	}
+	return "http://localhost:8431"
+}
+
 func init() {
-	rootCmd.PersistentFlags().StringVar(&apiURL, "api-url", "http://localhost:8431", "Covalence API URL")
+	rootCmd.PersistentFlags().StringVar(&apiURL, "api-url", defaultAPIURL(), "Covalence API URL (or set COVALENCE_API_URL)")
 	rootCmd.PersistentFlags().StringVar(&apiKey, "api-key", "", "API key for authentication (or set COVALENCE_API_KEY)")
 	rootCmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 }

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -792,5 +792,16 @@ async function fetchAdapters() {
 
 refreshAll();
 
-// Auto-refresh every 30 seconds
-setInterval(refreshAll, 30000);
+// Auto-refresh every 5 minutes.
+//
+// Each `refreshAll` fires /admin/metrics, /admin/data-health,
+// /analysis/coverage, /analysis/whitespace, and /analysis/erosion
+// in parallel. /admin/data-health alone runs `sp_data_health_report`
+// which currently takes ~20 seconds against a 100K-edge graph, and
+// /admin/metrics holds the petgraph read lock for several seconds
+// while computing weakly-connected components. Polling every 30s
+// kept the graph read lock saturated, queued the periodic
+// `full_reload` writer behind it, and pushed search latency from
+// sub-second to 90+ seconds. 5 minutes is a reasonable refresh
+// cadence for an observability dashboard.
+setInterval(refreshAll, 5 * 60 * 1000);

--- a/engine/crates/covalence-core/src/graph/sync.rs
+++ b/engine/crates/covalence-core/src/graph/sync.rs
@@ -106,6 +106,16 @@ pub async fn sync_loop(pool: &sqlx::PgPool, graph: SharedGraph) -> Result<()> {
 /// Load all nodes and edges from PostgreSQL into the graph sidecar.
 ///
 /// Used on startup and for admin-triggered full reloads.
+///
+/// **Lock discipline:** the entire rebuild happens against a *local*
+/// `GraphSidecar` outside the shared lock. The shared write lock is
+/// only acquired at the very end to swap the new sidecar in. This
+/// keeps lock-hold time to a single move regardless of graph size.
+///
+/// Previously the implementation cleared `*graph` under the write
+/// lock and inserted nodes/edges row-by-row while holding it. With
+/// 100K+ edges that meant 30+ seconds of write-lock contention every
+/// reload, blocking every search dimension that wanted a read lock.
 pub async fn full_reload(pool: &sqlx::PgPool, graph: SharedGraph) -> Result<()> {
     // Fetch all nodes via stored procedure.
     let node_rows = sqlx::query("SELECT * FROM sp_load_all_nodes()")
@@ -117,14 +127,14 @@ pub async fn full_reload(pool: &sqlx::PgPool, graph: SharedGraph) -> Result<()> 
         .fetch_all(pool)
         .await?;
 
-    let mut g = super::instrumented_lock::write_graph(&graph, "full_reload").await;
-    // Clear existing graph
-    *g = GraphSidecar::new();
+    // Build the new sidecar OFF-LOCK. Searches keep reading the
+    // current graph during the rebuild.
+    let mut new_graph = GraphSidecar::new();
 
     // Insert nodes (SP returns canonical_type = COALESCE(canonical_type, node_type))
     let mut node_errors = 0usize;
     for row in &node_rows {
-        if let Err(e) = g.add_node(NodeMeta {
+        if let Err(e) = new_graph.add_node(NodeMeta {
             id: row.get("id"),
             node_type: row.get("canonical_type"),
             entity_class: row.get("entity_class"),
@@ -149,7 +159,7 @@ pub async fn full_reload(pool: &sqlx::PgPool, graph: SharedGraph) -> Result<()> 
             _ => None,
         };
 
-        if let Err(e) = g.add_edge(
+        if let Err(e) = new_graph.add_edge(
             row.get("source_node_id"),
             row.get("target_node_id"),
             EdgeMeta {
@@ -168,6 +178,16 @@ pub async fn full_reload(pool: &sqlx::PgPool, graph: SharedGraph) -> Result<()> 
         }
     }
 
+    let nodes = new_graph.node_count();
+    let edges = new_graph.edge_count();
+
+    // Brief write-lock acquisition just to swap in the rebuilt graph.
+    // This is the only window in which concurrent readers are blocked.
+    {
+        let mut g = super::instrumented_lock::write_graph(&graph, "full_reload").await;
+        *g = new_graph;
+    }
+
     if node_errors > 0 || edge_errors > 0 {
         tracing::warn!(
             node_errors,
@@ -176,11 +196,7 @@ pub async fn full_reload(pool: &sqlx::PgPool, graph: SharedGraph) -> Result<()> 
         );
     }
 
-    tracing::info!(
-        nodes = g.node_count(),
-        edges = g.edge_count(),
-        "full graph reload complete"
-    );
+    tracing::info!(nodes, edges, "full graph reload complete");
 
     Ok(())
 }

--- a/engine/crates/covalence-core/src/ingestion/code_chunker.rs
+++ b/engine/crates/covalence-core/src/ingestion/code_chunker.rs
@@ -75,6 +75,31 @@ impl CodeLanguage {
         }
     }
 
+    /// Tree-sitter node kinds that represent attributes/annotations
+    /// that appear as siblings of (and conceptually attach to) the
+    /// following top-level item.
+    ///
+    /// These nodes are buffered while walking the AST and prepended
+    /// to the next top-level item's source text. Without this, Rust
+    /// attribute siblings like `#[derive(...)]` and
+    /// `#[async_trait::async_trait]` end up dumped into the
+    /// preamble section, which (a) loses their attachment to the
+    /// item they decorate, and (b) produces a junk chunk named
+    /// `[derive(...)]` whenever clusters of attributes happen to
+    /// fall together at the top of a file.
+    fn attribute_kinds(self) -> &'static [&'static str] {
+        match self {
+            // tree-sitter-rust parses outer attributes as
+            // `attribute_item` siblings of the item they decorate.
+            Self::Rust => &["attribute_item", "inner_attribute_item"],
+            // Python's `decorated_definition` already wraps the
+            // decorator + def together, so no buffering needed.
+            // Other languages don't have this sibling-attribute
+            // pattern at the top level.
+            _ => &[],
+        }
+    }
+
     /// Tree-sitter node kinds that represent top-level items.
     fn top_level_kinds(self) -> &'static [&'static str] {
         match self {
@@ -144,7 +169,15 @@ impl CodeLanguage {
 struct CodeItem {
     /// Human-readable label (e.g. "fn foo", "struct Bar", "class Baz").
     label: String,
-    /// The full source text of this item.
+    /// Attribute/annotation source text that decorates the item
+    /// (e.g. `#[derive(Debug, Clone)]` for Rust). May be empty.
+    /// Stored separately from `text` so that compound items (impl
+    /// blocks, classes) can emit attributes alongside the brief
+    /// header instead of dropping them when only methods are
+    /// rendered as code blocks.
+    attrs: String,
+    /// The full source text of this item (excluding attached
+    /// attributes — those live in `attrs`).
     text: String,
     /// Methods inside compound items (impl blocks, classes).
     /// When non-empty, each method gets its own sub-section chunk.
@@ -182,10 +215,15 @@ pub fn code_to_markdown(source: &str, lang: CodeLanguage) -> Result<String> {
 
     let root = tree.root_node();
     let top_level_kinds = lang.top_level_kinds();
+    let attribute_kinds = lang.attribute_kinds();
     let fence = lang.fence_tag();
 
     let mut items: Vec<CodeItem> = Vec::new();
     let mut preamble_ranges: Vec<(usize, usize)> = Vec::new();
+    // Buffer for attribute_item siblings (Rust's `#[derive(...)]`,
+    // `#[async_trait]`, etc.) that should attach to the next top-
+    // level item rather than fall into the preamble.
+    let mut pending_attrs: Vec<(usize, usize)> = Vec::new();
 
     let cursor_node_count = root.child_count() as u32;
     for i in 0..cursor_node_count {
@@ -196,20 +234,49 @@ pub fn code_to_markdown(source: &str, lang: CodeLanguage) -> Result<String> {
         let text = &source[node.start_byte()..node.end_byte()];
 
         if top_level_kinds.contains(&kind) {
+            // Collect any buffered attributes into a prefix string
+            // so the rendered chunk shows `#[derive(...)]` next to
+            // the struct it decorates. Stored separately from the
+            // item text so compound items (impl blocks, classes)
+            // can emit attributes alongside the brief header even
+            // when their full body is split into per-method chunks.
+            let attrs = pending_attrs
+                .iter()
+                .map(|(s, e)| source[*s..*e].trim())
+                .filter(|t| !t.is_empty())
+                .collect::<Vec<_>>()
+                .join("\n");
             let label = extract_label(source, &node, lang);
             let methods = extract_methods(source, &node, lang);
             items.push(CodeItem {
                 label,
+                attrs,
                 text: text.to_string(),
                 methods,
             });
+            pending_attrs.clear();
+        } else if attribute_kinds.contains(&kind) {
+            // Buffer — likely belongs to the next top-level item.
+            pending_attrs.push((node.start_byte(), node.end_byte()));
         } else if kind != "line_comment"
             && kind != "block_comment"
             && kind != "comment"
             && !text.trim().is_empty()
         {
+            // Some other top-level construct landed between buffered
+            // attributes and any item — flush the buffer into the
+            // preamble so we don't drop the attribute text entirely.
+            for range in pending_attrs.drain(..) {
+                preamble_ranges.push(range);
+            }
             preamble_ranges.push((node.start_byte(), node.end_byte()));
         }
+    }
+
+    // Anything still pending at EOF (e.g. trailing `#[cfg(test)]`
+    // followed by no item we recognize) goes to the preamble.
+    for range in pending_attrs.drain(..) {
+        preamble_ranges.push(range);
     }
 
     let mut md = String::new();
@@ -235,11 +302,24 @@ pub fn code_to_markdown(source: &str, lang: CodeLanguage) -> Result<String> {
     for item in &items {
         md.push_str(&format!("# {}\n\n", item.label));
         if item.methods.is_empty() {
-            md.push_str(&format!("```{fence}\n{}\n```\n\n", item.text));
+            // Prepend buffered attribute lines so the rendered code
+            // block matches the original source layout.
+            let body = if item.attrs.is_empty() {
+                item.text.clone()
+            } else {
+                format!("{}\n{}", item.attrs, item.text)
+            };
+            md.push_str(&format!("```{fence}\n{body}\n```\n\n"));
         } else {
-            // Emit the impl/class header as a brief code block, then
-            // each method as a sub-section.
-            md.push_str(&format!("```{fence}\n{}\n```\n\n", item.label));
+            // Emit the impl/class header (with attached attributes)
+            // as a brief code block, then each method as a
+            // sub-section.
+            let header = if item.attrs.is_empty() {
+                item.label.clone()
+            } else {
+                format!("{}\n{}", item.attrs, item.label)
+            };
+            md.push_str(&format!("```{fence}\n{header}\n```\n\n"));
             for method in &item.methods {
                 md.push_str(&format!("## {}\n\n", method.label));
                 md.push_str(&format!("```{fence}\n{}\n```\n\n", method.text));
@@ -295,6 +375,7 @@ fn extract_methods(source: &str, node: &tree_sitter::Node, lang: CodeLanguage) -
             let text = source[child.start_byte()..child.end_byte()].to_string();
             methods.push(CodeItem {
                 label,
+                attrs: String::new(),
                 text,
                 methods: Vec::new(),
             });
@@ -717,6 +798,75 @@ pub fn public_fn(x: &str) -> String {
 "#;
         let md = code_to_markdown(source.trim(), CodeLanguage::Rust).unwrap();
         assert!(md.contains("# pub fn public_fn"));
+    }
+
+    #[test]
+    fn rust_attributes_attach_to_following_item() {
+        // Regression: clusters of `#[derive(...)]` /
+        // `#[async_trait]` siblings used to land in the preamble
+        // section, producing chunks named `[derive(Debug, Clone)]`
+        // with no body. They should now be folded into the next
+        // top-level item.
+        let source = r#"
+#[derive(Debug, Clone)]
+#[derive(Serialize)]
+pub struct Foo {
+    pub bar: i32,
+}
+
+#[async_trait::async_trait]
+impl SomeTrait for Foo {
+    async fn do_thing(&self) -> i32 {
+        self.bar
+    }
+}
+"#;
+        let md = code_to_markdown(source.trim(), CodeLanguage::Rust).unwrap();
+
+        // No preamble section — attributes should not have leaked
+        // into one.
+        assert!(
+            !md.contains("# Preamble"),
+            "attributes leaked into preamble:\n{md}"
+        );
+
+        // The struct chunk should carry both `#[derive]` lines.
+        assert!(md.contains("# struct Foo"));
+        let struct_section_start = md.find("# struct Foo").unwrap();
+        let after_struct = &md[struct_section_start..];
+        assert!(
+            after_struct.contains("#[derive(Debug, Clone)]"),
+            "struct chunk missing #[derive(Debug, Clone)]:\n{after_struct}"
+        );
+        assert!(
+            after_struct.contains("#[derive(Serialize)]"),
+            "struct chunk missing #[derive(Serialize)]:\n{after_struct}"
+        );
+
+        // The impl chunk should carry the async_trait attribute.
+        assert!(md.contains("# impl SomeTrait for Foo"));
+        let impl_section_start = md.find("# impl SomeTrait for Foo").unwrap();
+        let after_impl = &md[impl_section_start..];
+        assert!(
+            after_impl.contains("#[async_trait::async_trait]"),
+            "impl chunk missing #[async_trait]:\n{after_impl}"
+        );
+    }
+
+    #[test]
+    fn rust_orphan_attribute_falls_through_to_preamble() {
+        // If an attribute has no following top-level item it should
+        // still surface somewhere — fall through to the preamble so
+        // we never silently drop source text.
+        let source = r#"
+#[cfg(test)]
+"#;
+        let md = code_to_markdown(source.trim(), CodeLanguage::Rust).unwrap();
+        // tree-sitter may parse a lone `#[cfg(test)]` differently
+        // depending on grammar version; the contract here is just
+        // that we don't silently drop it. Either it lands in the
+        // preamble or in the fallback Source section.
+        assert!(md.contains("cfg(test)") || md.contains("# Source"));
     }
 
     #[test]

--- a/engine/crates/covalence-core/src/search/cache.rs
+++ b/engine/crates/covalence-core/src/search/cache.rs
@@ -9,6 +9,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use crate::error::Result;
+use crate::ingestion::embedder::truncate_and_validate;
 use crate::search::fusion::FusedResult;
 
 /// Configuration for the semantic query cache.
@@ -54,12 +55,25 @@ pub struct CachedResponse {
 pub struct QueryCache {
     pool: PgPool,
     config: CacheConfig,
+    /// Truncation dimension for query embeddings.
+    ///
+    /// The `query_cache.query_embedding` column is `halfvec(1024)`
+    /// (see migration `005_search.sql`). Embedders generate vectors
+    /// at the engine's max dimension (typically 2048 for source); we
+    /// truncate + L2-renormalize before INSERT/SELECT so the column
+    /// type matches. Without this, every cache write fails with
+    /// `expected 1024 dimensions, not 2048` and every query is a miss.
+    dim: usize,
 }
 
 impl QueryCache {
-    /// Create a new query cache with the given pool and config.
-    pub fn new(pool: PgPool, config: CacheConfig) -> Self {
-        Self { pool, config }
+    /// Create a new query cache with the given pool, config, and
+    /// embedding truncation dimension.
+    ///
+    /// `dim` must match the `query_embedding` column dimension
+    /// (currently 1024 — see migration `005_search.sql`).
+    pub fn new(pool: PgPool, config: CacheConfig, dim: usize) -> Self {
+        Self { pool, config, dim }
     }
 
     /// Look up a semantically similar cached query.
@@ -73,9 +87,10 @@ impl QueryCache {
         query_embedding: &[f64],
         strategy: &str,
     ) -> Result<Option<Vec<FusedResult>>> {
+        let truncated = truncate_and_validate(query_embedding, self.dim, "query_cache")?;
         let pgvec = format!(
             "[{}]",
-            query_embedding
+            truncated
                 .iter()
                 .map(|v| v.to_string())
                 .collect::<Vec<_>>()
@@ -87,8 +102,16 @@ impl QueryCache {
 
         // Find the closest cached embedding within TTL and
         // distance threshold, matching strategy.
+        //
+        // The SP returns `(id UUID, response JSONB)` — column name is
+        // `response`, not `results`. The previous SELECT referenced
+        // `results` and threw `column "results" does not exist` on
+        // every lookup. The error was caught and downgraded to a
+        // tracing::warn! ("cache lookup failed, proceeding without
+        // cache") so search still returned results, but every query
+        // was a hard miss against the cache regardless of contents.
         let row: Option<(Uuid, serde_json::Value)> = sqlx::query_as(
-            "SELECT id, results \
+            "SELECT id, response \
              FROM sp_lookup_query_cache($1::halfvec, $2, $3, $4)",
         )
         .bind(&pgvec)
@@ -137,9 +160,10 @@ impl QueryCache {
         strategy: &str,
         results: &[FusedResult],
     ) -> Result<()> {
+        let truncated = truncate_and_validate(query_embedding, self.dim, "query_cache")?;
         let pgvec = format!(
             "[{}]",
-            query_embedding
+            truncated
                 .iter()
                 .map(|v| v.to_string())
                 .collect::<Vec<_>>()

--- a/engine/crates/covalence-core/src/services/pipeline/mod.rs
+++ b/engine/crates/covalence-core/src/services/pipeline/mod.rs
@@ -674,14 +674,14 @@ impl SourceService {
                             .and_then(|v| v.as_str())
                             .unwrap_or("unknown");
 
-                        let prompt = super::prompts::build_summary_prompt(
+                        let (system, user) = super::prompts::build_summary_prompt(
                             &node.canonical_name,
                             &node.node_type,
                             file_path,
                             raw,
                         );
 
-                        match chat.chat("", &prompt, false, 0.2).await {
+                        match chat.chat(&system, &user, false, 0.2).await {
                             Ok(resp) if !resp.text.trim().is_empty() => {
                                 let summary = resp.text.trim().to_string();
                                 // Store summary in properties and update

--- a/engine/crates/covalence-core/src/services/prompts.rs
+++ b/engine/crates/covalence-core/src/services/prompts.rs
@@ -112,19 +112,70 @@ pub fn wrap_input(tag: &str, content: &str) -> String {
     format!("<{tag}>\n{content}\n</{tag}>")
 }
 
+/// Maximum code bytes to include in the summary prompt.
+///
+/// Large AST chunks (e.g., an entire impl block with many methods)
+/// can blow past a model's context window. We truncate to keep the
+/// prompt within budget while preserving syntactic coherence.
+const MAX_CODE_BYTES: usize = 3000;
+
+/// Truncate a code string at a line boundary so we never cut in
+/// the middle of a token or multi-byte UTF-8 character.
+///
+/// Returns the full string if it's already within the limit.
+fn truncate_code(code: &str, max_bytes: usize) -> &str {
+    if code.len() <= max_bytes {
+        return code;
+    }
+    // First, snap to a valid char boundary so we can safely search
+    // for newlines. This prevents panics on multi-byte UTF-8.
+    let mut safe_end = max_bytes;
+    while safe_end > 0 && !code.is_char_boundary(safe_end) {
+        safe_end -= 1;
+    }
+    // Find the last newline before the safe limit. This keeps
+    // every included line syntactically complete, which reduces
+    // LLM hallucinations from broken code fragments.
+    match code[..safe_end].rfind('\n') {
+        Some(pos) => &code[..pos],
+        // No newline found (single very-long line): return the
+        // char-boundary-safe slice.
+        None => &code[..safe_end],
+    }
+}
+
 /// Build a code summary prompt by filling in template variables.
+///
+/// Returns `(system_prompt, user_prompt)`. The template's
+/// instruction text ("You are a code analysis engine...") becomes
+/// the system prompt, while the entity metadata and code go into
+/// the user prompt. This matches the role-separation pattern used
+/// by the entity extraction pipeline and improves instruction-
+/// following from the LLM.
 pub fn build_summary_prompt(
     entity_name: &str,
     entity_type: &str,
     file_path: &str,
     code: &str,
-) -> String {
+) -> (String, String) {
     let template = code_summary_template();
-    template
+    let code = truncate_code(code, MAX_CODE_BYTES);
+
+    // Split at the <entity> tag: everything before is the system
+    // prompt (instructions), everything from <entity> onward is
+    // the user prompt (data).
+    let (system, user_template) = match template.find("<entity>") {
+        Some(pos) => (template[..pos].trim(), &template[pos..]),
+        None => (template, ""),
+    };
+
+    let user = user_template
         .replace("{{name}}", entity_name)
         .replace("{{type}}", entity_type)
         .replace("{{file}}", file_path)
-        .replace("{{code}}", &code[..code.len().min(3000)])
+        .replace("{{code}}", code);
+
+    (system.to_string(), user)
 }
 
 /// Wrap document text for entity extraction.
@@ -140,4 +191,53 @@ pub fn wrap_statements(text: &str) -> String {
 /// Wrap section list for source summary.
 pub fn wrap_sections(text: &str) -> String {
     wrap_input("sections", text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_code_short_string_unchanged() {
+        let code = "fn main() {}";
+        assert_eq!(truncate_code(code, 3000), code);
+    }
+
+    #[test]
+    fn truncate_code_at_line_boundary() {
+        let code = "line1\nline2\nline3\nline4\n";
+        // Limit that falls in the middle of "line3"
+        let result = truncate_code(code, 14);
+        assert_eq!(result, "line1\nline2");
+    }
+
+    #[test]
+    fn truncate_code_utf8_safe() {
+        // "é" is 2 bytes — a limit of 5 falls in the middle
+        let code = "abc\néfg";
+        let result = truncate_code(code, 5);
+        // Should cut at the newline before "é"
+        assert_eq!(result, "abc");
+    }
+
+    #[test]
+    fn build_summary_prompt_returns_system_user_pair() {
+        let (system, user) = build_summary_prompt("Foo", "struct", "src/foo.rs", "struct Foo {}");
+        assert!(
+            system.contains("code analysis engine"),
+            "system prompt should have instructions"
+        );
+        assert!(
+            user.contains("<entity>"),
+            "user prompt should have entity tag"
+        );
+        assert!(
+            user.contains("struct Foo {}"),
+            "user prompt should have code"
+        );
+        assert!(
+            !system.contains("<entity>"),
+            "system prompt should NOT have entity data"
+        );
+    }
 }

--- a/engine/crates/covalence-core/src/services/queue/handlers.rs
+++ b/engine/crates/covalence-core/src/services/queue/handlers.rs
@@ -197,7 +197,7 @@ async fn summarize_single_entity(
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
 
-    let prompt = crate::services::prompts::build_summary_prompt(
+    let (system, user) = crate::services::prompts::build_summary_prompt(
         &node.canonical_name,
         &node.node_type,
         file_path,
@@ -205,7 +205,7 @@ async fn summarize_single_entity(
     );
 
     let start = Instant::now();
-    let chat_response = chat.chat("", &prompt, false, 0.2).await?;
+    let chat_response = chat.chat(&system, &user, false, 0.2).await?;
     let duration_ms = start.elapsed().as_millis() as i64;
 
     let provider = chat_response.provider;

--- a/engine/crates/covalence-core/src/services/search/enrichment.rs
+++ b/engine/crates/covalence-core/src/services/search/enrichment.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::graph::engine::GraphEngine;
+use crate::models::source::Source;
 use crate::search::fusion::{FusedResult, RelatedEntity};
 use crate::storage::postgres::PgRepo;
 use crate::storage::traits::{
@@ -21,6 +22,27 @@ use crate::types::ids::{ArticleId, ChunkId, NodeId, SectionId, StatementId};
 use super::super::search_helpers::{
     derive_chunk_name_qualified, kwic_snippet, truncate_with_ellipsis,
 };
+
+/// Effective `source_type` for display in search results.
+///
+/// `sources.source_type` is set at ingest time from caller input
+/// (e.g. `--type document`), but the pipeline detects code via
+/// `is_code` (URI/MIME) and routes those sources through the CODE
+/// profile regardless. That means a `.rs` file ingested as `document`
+/// gets correctly chunked and AST-extracted as code, but the PG row
+/// keeps saying `document` and search results were misleading.
+///
+/// `domains` is the authoritative classification — domain rules and
+/// adapters set it from the same `is_code` detection. So when
+/// `domains` contains `code` we surface `code` in search results
+/// regardless of the lagging `source_type` row. The PG row stays
+/// untouched (it represents the original user intent).
+fn effective_source_type(source: &Source) -> String {
+    if source.domains.iter().any(|d| d == "code") {
+        return "code".to_string();
+    }
+    source.source_type.clone()
+}
 
 /// Enrich fused results with entity metadata (Step 8).
 ///
@@ -80,11 +102,14 @@ async fn enrich_source(result: &mut FusedResult, repo: &Arc<PgRepo>) {
     if let Ok(Some(source)) =
         SourceRepo::get(&**repo, crate::types::ids::SourceId::from_uuid(result.id)).await
     {
+        // Compute the effective source_type BEFORE consuming any
+        // fields of `source`, since the helper takes `&Source`.
+        let effective = effective_source_type(&source);
         result.name = source.title.clone();
         result.entity_type = Some("source".to_string());
         result.source_uri = source.uri;
         result.source_title = source.title;
-        result.source_type = Some(source.source_type.clone());
+        result.source_type = Some(effective);
         result.source_domains = source.domains.clone();
         result.created_at = Some(source.ingested_at.to_rfc3339());
         // Use truncated raw content for snippet.
@@ -103,9 +128,10 @@ async fn enrich_statement(result: &mut FusedResult, repo: &Arc<PgRepo>, query: &
         result.created_at = Some(stmt.created_at.to_rfc3339());
         // Look up source for URI/title.
         if let Ok(Some(source)) = SourceRepo::get(&**repo, stmt.source_id).await {
+            let effective = effective_source_type(&source);
             result.source_uri = source.uri;
             result.source_title = source.title.clone();
-            result.source_type = Some(source.source_type.clone());
+            result.source_type = Some(effective);
             result.source_domains = source.domains.clone();
         }
         // Use the statement content as name (truncated).
@@ -126,9 +152,10 @@ async fn enrich_section(result: &mut FusedResult, repo: &Arc<PgRepo>, query: &st
         result.created_at = Some(sect.created_at.to_rfc3339());
         // Look up source for URI/title.
         if let Ok(Some(source)) = SourceRepo::get(&**repo, sect.source_id).await {
+            let effective = effective_source_type(&source);
             result.source_uri = source.uri;
             result.source_title = source.title.clone();
-            result.source_type = Some(source.source_type.clone());
+            result.source_type = Some(effective);
             result.source_domains = source.domains.clone();
         }
         // Content-based snippet fallback.
@@ -148,9 +175,10 @@ async fn enrich_chunk_or_fallback(result: &mut FusedResult, repo: &Arc<PgRepo>, 
         // Look up source first so we can qualify generic chunk
         // headings with the source title.
         let src_title = if let Ok(Some(source)) = SourceRepo::get(&**repo, chunk.source_id).await {
+            let effective = effective_source_type(&source);
             result.source_uri = source.uri;
             result.source_title = source.title.clone();
-            result.source_type = Some(source.source_type.clone());
+            result.source_type = Some(effective);
             result.source_domains = source.domains.clone();
             result.created_at = Some(source.ingested_at.to_rfc3339());
             source.title
@@ -191,11 +219,12 @@ async fn enrich_chunk_or_fallback(result: &mut FusedResult, repo: &Arc<PgRepo>, 
         if let Ok(Some(source)) =
             SourceRepo::get(&**repo, crate::types::ids::SourceId::from_uuid(result.id)).await
         {
+            let effective = effective_source_type(&source);
             result.name = source.title.clone();
             result.entity_type = Some("source".to_string());
             result.source_uri = source.uri;
             result.source_title = source.title;
-            result.source_type = Some(source.source_type.clone());
+            result.source_type = Some(effective);
             result.source_domains = source.domains.clone();
             result.created_at = Some(source.ingested_at.to_rfc3339());
             if let Some(ref raw) = source.raw_content {
@@ -269,5 +298,42 @@ pub(super) async fn enrich_graph_context(
         if !related.is_empty() {
             result.graph_context = Some(related);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::source::SourceType;
+
+    fn make_source(source_type: &str, domains: Vec<&str>) -> Source {
+        // Reuse Source::new for the heavy lifting; override the
+        // raw type string + domains for the test scenario.
+        let mut s = Source::new(SourceType::Document, vec![0u8; 32]);
+        s.source_type = source_type.to_string();
+        s.domains = domains.into_iter().map(String::from).collect();
+        s
+    }
+
+    #[test]
+    fn effective_source_type_promotes_code_domain_over_lagging_type() {
+        // Regression: a `.rs` file ingested as `--type document`
+        // gets routed through the CODE profile but the PG row's
+        // `source_type` keeps saying `document`. We want search
+        // results to surface `code` so callers see the truth.
+        let source = make_source("document", vec!["code"]);
+        assert_eq!(effective_source_type(&source), "code");
+    }
+
+    #[test]
+    fn effective_source_type_passes_through_when_no_code_domain() {
+        let source = make_source("document", vec!["spec", "external"]);
+        assert_eq!(effective_source_type(&source), "document");
+    }
+
+    #[test]
+    fn effective_source_type_passes_through_when_domains_empty() {
+        let source = make_source("web_page", vec![]);
+        assert_eq!(effective_source_type(&source), "web_page");
     }
 }

--- a/engine/crates/covalence-core/src/services/search/mod.rs
+++ b/engine/crates/covalence-core/src/services/search/mod.rs
@@ -56,6 +56,10 @@ pub struct SearchService {
     pub(super) global: GlobalDimension,
     pub(super) reranker: Arc<dyn Reranker>,
     pub(super) cache: Option<QueryCache>,
+    /// Truncation dim used when constructing the query cache.
+    /// Captured from `TableDimensions::chunk` in `with_config` so
+    /// that `with_cache` can hand it to [`QueryCache::new`].
+    pub(super) cache_dim: usize,
     pub(super) abstention_config: AbstentionConfig,
     /// Use Convex Combination fusion instead of RRF.
     /// CC preserves score magnitude; RRF uses only rank.
@@ -91,6 +95,7 @@ impl SearchService {
         let pool = repo.pool().clone();
         let graph_engine: Arc<dyn GraphEngine> =
             Arc::new(crate::graph::PetgraphEngine::new(Arc::clone(&graph)));
+        let cache_dim = table_dims.chunk;
         Self {
             repo,
             embedder,
@@ -104,6 +109,7 @@ impl SearchService {
             graph: Arc::clone(&graph),
             reranker: Arc::new(NoopReranker),
             cache: None,
+            cache_dim,
             abstention_config: AbstentionConfig::default(),
             use_cc_fusion: true,
             internal_domains: ["code", "spec", "design"]
@@ -147,7 +153,7 @@ impl SearchService {
     /// the full search pipeline.
     pub fn with_cache(mut self, config: CacheConfig) -> Self {
         let pool = self.repo.pool().clone();
-        self.cache = Some(QueryCache::new(pool, config));
+        self.cache = Some(QueryCache::new(pool, config, self.cache_dim));
         self
     }
 


### PR DESCRIPTION
## Summary

Six fixes surfaced by trying the system end-to-end after #190 merged. Same query (`ChainChatBackend fallback chain provider`) that took **227 seconds** before this branch now returns in **1.06s cold** and **0.13s warm** against the same 358-source dataset.

| # | Bug | Fix |
|---|---|---|
| 1 | Search cache halfvec(1024) dim mismatch — every write failed with `expected 1024 dimensions, not 2048` | `QueryCache::new` takes a `dim` plumbed from `SearchService.cache_dim` (= `TableDimensions::chunk`); calls `truncate_and_validate` inside `lookup`/`store` |
| 2 | Pre-existing cache lookup column-name typo — `SELECT id, results` but SP returns `(id, response)`; lookup error was downgraded to a `tracing::warn` so this had been silently failing forever | One-line SELECT fix |
| 3 | `graph::sync::full_reload` held the write lock for the entire 30+s rebuild, causing 60-90s contention waits in the slow-lock log | Build new `GraphSidecar` in a local off-lock; only acquire the write lock briefly to swap |
| 4 | Code chunker emitted pure-attribute chunks like `[derive(Debug, Clone)]` because `attribute_item` siblings dumped into the preamble | `CodeItem.attrs` field; sibling attributes buffered and prepended; emitted with the brief header for compound items so `#[async_trait]` survives the impl-block method-split. Two regression tests added. |
| 5 | Search results showed `source_type=document` for `.rs` files because the PG row lags `is_code` detection (#190 fixed the pipeline path but not the display) | `effective_source_type(&Source)` helper promotes `"code"` from `source.domains` over the lagging field, used at all five enrichment sites. PG row untouched. |
| 6 | `cove` CLI ignored `COVALENCE_API_URL`, hardcoded `http://localhost:8431` | `defaultAPIURL()` reads env var first |

Plus: dashboard auto-refresh bumped from 30s to 5min. `/admin/data-health` calls `sp_data_health_report` which currently takes ~20s, and `/admin/metrics` holds the petgraph read lock while computing weakly-connected components. Polling every 30s saturated the graph and queued every reader behind the periodic `full_reload` writer.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --lib -- -D warnings` clean
- [x] `cargo test --workspace` — 1594 passing (1511 core + 49 eval + 21 api + 13 ast-extractor), 18 ignored integration tests
- [x] `code_chunker::tests::rust_attributes_attach_to_following_item` (new)
- [x] `code_chunker::tests::rust_orphan_attribute_falls_through_to_preamble` (new)
- [x] `services::search::enrichment::tests::effective_source_type_*` (new)
- [x] Live verification on prod-attached engine: cold search 227s → 1.06s, warm 0.13s with `cache_hit=true execution_ms=115`
- [x] Code review via `cove llm --model haiku` — LGTM, two follow-ups verified

## Follow-ups not addressed in this PR

- `sp_data_health_report` taking ~20s is a real query optimization opportunity (separate bug)
- `PetgraphEngine::stats` recomputes weakly-connected components on every call without caching — a callsite optimization for later
- Issue #176 still has 193 of 313 `.rs`/`.go` sources to reprocess through the now-fixed pipeline
- Follow-up #191 (LLM-typed → AST node promotion) still open

🤖 Generated with [Claude Code](https://claude.com/claude-code)