### PR TITLE
Cross-statement entity dedup before resolution (#196)

### DIFF
--- a/engine/crates/covalence-core/src/services/pipeline/statement_extraction.rs
+++ b/engine/crates/covalence-core/src/services/pipeline/statement_extraction.rs
@@ -1,31 +1,57 @@
 //! Statement-level entity extraction.
 //!
 //! Extracts entities and relationships from stored statements for a
-//! given source. Statements are self-contained text, so they work as
-//! extraction input without windowing or batching. Creates extraction
-//! records with `statement_id` provenance.
+//! given source. Uses a three-phase approach:
+//!
+//! 1. **Extract** — concurrent LLM extraction from all statements.
+//! 2. **Dedup** — accumulate entities across all statements and
+//!    resolve each unique entity name once (not once per statement).
+//! 3. **Link** — process relationships per-statement using the
+//!    resolved `name_to_node` map.
+//!
+//! Cross-statement dedup (#196) prevents redundant resolution:
+//! if "Rust" is extracted from 50 statements, it's resolved once
+//! instead of 50 times (50 advisory locks + potential embedding
+//! API calls). Each source statement still gets an extraction
+//! provenance record linking it to the resolved node.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::error::{Error, Result};
 use crate::ingestion::embedder::truncate_and_validate;
-use crate::ingestion::extractor::ExtractionContext;
+use crate::ingestion::extractor::{ExtractedEntity, ExtractionContext};
 use crate::models::edge::Edge;
 use crate::models::extraction::{ExtractedEntityType, Extraction};
 use crate::storage::traits::{EdgeRepo, ExtractionRepo, NodeRepo};
-use crate::types::ids::{NodeId, SourceId};
+use crate::types::ids::{NodeId, SourceId, StatementId};
 
 use super::super::noise_filter::is_noise_entity;
 use super::super::source::SourceService;
 use super::types::ExtractionProvenance;
 
+/// An entity deduplicated across multiple statements.
+///
+/// When the same entity name appears in multiple statements from the
+/// same source, we keep the highest-confidence instance and track
+/// all originating statement IDs for multi-provenance.
+struct DedupedEntity {
+    /// The entity instance with the highest confidence.
+    entity: ExtractedEntity,
+    /// All statement IDs that produced this entity name.
+    source_statements: Vec<StatementId>,
+}
+
 impl SourceService {
     /// Run entity extraction on stored statements.
     ///
-    /// Reuses the existing `Extractor` trait — statements are
-    /// self-contained text, so they work as extraction input without
-    /// windowing or batching. Creates extraction records with
-    /// `statement_id` provenance.
+    /// Three-phase pipeline:
+    /// 1. Concurrent LLM extraction from all non-evicted statements.
+    /// 2. Cross-statement entity dedup — accumulate all entities,
+    ///    keep the highest-confidence instance per lowercase name,
+    ///    resolve once per unique entity.
+    /// 3. Per-statement relationship linking using the resolved
+    ///    `name_to_node` map.
     pub(crate) async fn extract_entities_from_statements(
         &self,
         source_id: SourceId,
@@ -49,11 +75,8 @@ impl SourceService {
         });
 
         let semaphore = Arc::new(tokio::sync::Semaphore::new(self.extract_concurrency));
-        let mut entity_count = 0usize;
-        let mut name_to_node: std::collections::HashMap<String, NodeId> =
-            std::collections::HashMap::new();
 
-        // Extract from each statement (they're already self-contained).
+        // ── Phase 1: Concurrent LLM extraction ──────────────────
         let batch_futures: Vec<_> = statements
             .iter()
             .filter(|s| !s.is_evicted)
@@ -74,47 +97,108 @@ impl SourceService {
             })
             .collect();
 
-        let results = futures::future::join_all(batch_futures).await;
+        let raw_results = futures::future::join_all(batch_futures).await;
 
-        for result in results {
-            let (stmt_id, extraction) = match result {
-                Ok(r) => r,
+        // Collect successful results; warn and skip failures.
+        let mut extraction_results = Vec::new();
+        for result in raw_results {
+            match result {
+                Ok(r) => extraction_results.push(r),
                 Err(e) => {
                     tracing::warn!(
                         error = %e,
                         "statement entity extraction failed, skipping"
                     );
+                }
+            }
+        }
+
+        // ── Phase 2: Cross-statement entity dedup ───────────────
+        //
+        // Accumulate all entities across all statements. For each
+        // unique name (case-insensitive), keep the highest-confidence
+        // instance and track all originating statement IDs.
+        let mut entity_map: HashMap<String, DedupedEntity> = HashMap::new();
+        let mut raw_entity_count = 0usize;
+
+        for (stmt_id, extraction) in &extraction_results {
+            for entity in &extraction.entities {
+                if is_noise_entity(&entity.name, &entity.entity_type) {
                     continue;
                 }
-            };
-
-            // Dedup entities by name to prevent advisory lock contention (#171).
-            // Note: sequential resolution is correct here because the
-            // relationship loop below depends on name_to_node being
-            // fully populated. Parallelism would break edge creation.
-            let mut seen = std::collections::HashSet::new();
-            for entity in extraction
-                .entities
-                .iter()
-                .filter(|e| !is_noise_entity(&e.name, &e.entity_type))
-                .filter(|e| seen.insert(e.name.to_lowercase()))
-            {
-                let node_id = self
-                    .resolve_and_store_entity(
-                        entity,
-                        ExtractionProvenance::Statement(stmt_id),
-                        "llm_statement",
-                        source_id,
-                        source_domain,
-                    )
-                    .await?;
-                let Some(node_id) = node_id else {
-                    continue;
-                };
-                name_to_node.insert(entity.name.to_lowercase(), node_id);
-                entity_count += 1;
+                raw_entity_count += 1;
+                let key = entity.name.to_lowercase();
+                entity_map
+                    .entry(key)
+                    .and_modify(|d| {
+                        d.source_statements.push(*stmt_id);
+                        if entity.confidence > d.entity.confidence {
+                            d.entity = entity.clone();
+                        }
+                    })
+                    .or_insert(DedupedEntity {
+                        entity: entity.clone(),
+                        source_statements: vec![*stmt_id],
+                    });
             }
+        }
 
+        let deduped_count = entity_map.len();
+        if raw_entity_count > deduped_count {
+            tracing::info!(
+                raw = raw_entity_count,
+                deduped = deduped_count,
+                saved = raw_entity_count - deduped_count,
+                "cross-statement entity dedup"
+            );
+        }
+
+        // Resolve each unique entity once and populate name_to_node.
+        let mut name_to_node: HashMap<String, NodeId> = HashMap::new();
+        let mut entity_count = 0usize;
+
+        for (key, deduped) in &entity_map {
+            // Resolve using the first statement as the primary
+            // provenance (the one inside the transaction).
+            let primary_stmt = deduped.source_statements[0];
+            let node_id = self
+                .resolve_and_store_entity(
+                    &deduped.entity,
+                    ExtractionProvenance::Statement(primary_stmt),
+                    "llm_statement",
+                    source_id,
+                    source_domain,
+                )
+                .await?;
+
+            let Some(node_id) = node_id else {
+                continue;
+            };
+            name_to_node.insert(key.clone(), node_id);
+            entity_count += 1;
+
+            // Create additional extraction records for the remaining
+            // source statements. This preserves full provenance —
+            // each statement that mentioned this entity gets a link
+            // to the resolved node — without re-running resolution.
+            for &stmt_id in &deduped.source_statements[1..] {
+                let ext_record = Extraction::from_statement(
+                    stmt_id,
+                    ExtractedEntityType::Node,
+                    node_id.into_uuid(),
+                    "llm_statement".to_string(),
+                    deduped.entity.confidence,
+                );
+                ExtractionRepo::create(&*self.repo, &ext_record).await?;
+            }
+        }
+
+        // ── Phase 3: Per-statement relationship linking ─────────
+        //
+        // Relationships are context-dependent — each belongs to its
+        // source statement. The name_to_node map (populated above)
+        // resolves entity names to node IDs for edge creation.
+        for (stmt_id, extraction) in &extraction_results {
             for rel in &extraction.relationships {
                 let src_key = rel.source_name.to_lowercase();
                 let tgt_key = rel.target_name.to_lowercase();
@@ -144,7 +228,7 @@ impl SourceService {
                 self.check_and_invalidate_conflicts(&edge).await?;
 
                 let ext_record = Extraction::from_statement(
-                    stmt_id,
+                    *stmt_id,
                     ExtractedEntityType::Edge,
                     edge.id.into_uuid(),
                     "llm_statement".to_string(),
@@ -154,7 +238,7 @@ impl SourceService {
             }
         }
 
-        // Embed new node descriptions.
+        // ── Embed new node descriptions ─────────────────────────
         if !name_to_node.is_empty() {
             if let Some(ref embedder) = self.embedder {
                 let node_ids: Vec<NodeId> = name_to_node.values().copied().collect();


### PR DESCRIPTION
## Summary

Restructures `extract_entities_from_statements()` into a three-phase pipeline that deduplicates entities across all statements in a source before resolution. If "Rust" is extracted from 50 statements, it's now resolved once instead of 50 times.

- **Phase 1 (Extract):** Concurrent LLM extraction from all statements — unchanged
- **Phase 2 (Dedup):** Accumulate all entities into `HashMap<String, DedupedEntity>` keyed by lowercase name, keeping the highest-confidence instance and tracking all originating statement IDs
- **Phase 3 (Link):** Resolve each unique entity once via `resolve_and_store_entity`, then create lightweight extraction provenance records for all remaining source statements. Process relationships per-statement using the populated `name_to_node` map.

**Impact:** For a source with 50 statements mentioning the same entity:
- Before: 50 advisory locks + up to 50 embedding API calls + 50 DB transactions
- After: 1 advisory lock + 1 embedding API call + 1 DB transaction + 49 lightweight INSERTs

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --lib -- -D warnings` clean
- [x] `cargo test --workspace` — 1598 passing
- [ ] End-to-end: ingest a source with repeated entity mentions, verify resolution call count drops

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)